### PR TITLE
Missing dataset factory is not silently ignored

### DIFF
--- a/lib/attachDataset.js
+++ b/lib/attachDataset.js
@@ -2,6 +2,9 @@ const fromStream = require('./fromStream')
 
 function attachDataset (res, factory) {
   res.dataset = async () => {
+    if (!factory) {
+      throw new Error('Missing dataset factory')
+    }
     const stream = await res.quadStream()
     return fromStream(factory.dataset(), stream)
   }

--- a/lib/patchResponse.js
+++ b/lib/patchResponse.js
@@ -3,10 +3,7 @@ const attachQuadStream = require('./attachQuadStream')
 
 function patchResponse (res, factory, fetch, parsers) {
   attachQuadStream(res, fetch, parsers)
-
-  if (factory) {
-    attachDataset(res, factory)
-  }
+  attachDataset(res, factory)
 
   return res
 }

--- a/test/response.js
+++ b/test/response.js
@@ -134,14 +134,17 @@ describe('response', () => {
   })
 
   describe('dataset', () => {
-    it('should be undefined if no factory is given', () => {
+    it('should throw when dataset factory is missing', async () => {
       const id = '/response/dataset/undefined'
 
       virtualResource({ id })
 
-      return rdfFetch(`http://example.org${id}`, { formats }).then(res => {
-        assert.strictEqual(typeof res.dataset, 'undefined')
-      })
+      const res = await rdfFetch(`http://example.org${id}`, { formats })
+      await res.dataset().then(
+        () => Promise.reject(new Error('Expected method to reject.')),
+        (err) => {
+          assert.strictEqual(err.message, `Missing dataset factory`)
+        })
     })
 
     it('should be a function', () => {


### PR DESCRIPTION
Close #3

When calling `dataset()`, `Error: Missing dataset factory` is more helpful than `TypeError: dataset is not a function`