### PR TITLE
default to RDF/XML if no Content-Type header

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function rdfFetch (url, options = {}) {
   options = patchRequest(options, formats)
 
   return fetch(url, options).then(res => {
-    return patchResponse(res, factory, fetch, formats.parsers)
+    return patchResponse(res, factory, fetch, formats.parsers, options)
   })
 }
 

--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -3,9 +3,10 @@ const jsonldContextLinkUrl = require('./jsonldContextLinkUrl')
 function attachQuadStream (res, fetch, parsers, options) {
   res.quadStream = async () => {
     let contentType
+    // If response has a Content-Type header use it, else fallback to an options-provided
+    // Content-Type, but if none provided throw an error.
     if (res.headers.get('content-type')) {
-      // Content type from headers without encoding, if given.
-      contentType = res.headers.get('content-type').split(';')[0]
+      contentType = res.headers.get('content-type')
     } else {
       if (options.headers['content-type']) {
         contentType = options.headers['content-type']
@@ -13,6 +14,9 @@ function attachQuadStream (res, fetch, parsers, options) {
         throw new Error('Fetch response provided no Content-Type header, and no content type option was provided.')
       }
     }
+
+    // Content type without encoding, if given.
+    contentType = contentType.split(';')[0]
 
     // JSON-LD context URL from headers
     const contextLinkUrl = jsonldContextLinkUrl(res, contentType)

--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -1,10 +1,18 @@
 const jsonldContextLinkUrl = require('./jsonldContextLinkUrl')
 
-function attachQuadStream (res, fetch, parsers) {
+function attachQuadStream (res, fetch, parsers, options) {
   res.quadStream = async () => {
-    // Content type from headers without encoding, if given, or default to RDF/XML if none at all.
-    let contentType = res.headers.get('content-type')
-      ? res.headers.get('content-type').split(';')[0] : 'application/rdf+xml'
+    let contentType
+    if (res.headers.get('content-type')) {
+      // Content type from headers without encoding, if given.
+      contentType = res.headers.get('content-type').split(';')[0]
+    } else {
+      if (options.headers['content-type']) {
+        contentType = options.headers['content-type']
+      } else {
+        throw new Error('Fetch response provided no Content-Type header, and no content type option was provided.')
+      }
+    }
 
     // JSON-LD context URL from headers
     const contextLinkUrl = jsonldContextLinkUrl(res, contentType)

--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -2,8 +2,9 @@ const jsonldContextLinkUrl = require('./jsonldContextLinkUrl')
 
 function attachQuadStream (res, fetch, parsers) {
   res.quadStream = async () => {
-    // content type from headers without encoding, if given
-    let contentType = res.headers.get('content-type').split(';')[0]
+    // Content type from headers without encoding, if given, or default to RDF/XML if none at all.
+    let contentType = res.headers.get('content-type')
+      ? res.headers.get('content-type').split(';')[0] : 'application/rdf+xml'
 
     // JSON-LD context URL from headers
     const contextLinkUrl = jsonldContextLinkUrl(res, contentType)

--- a/lib/patchResponse.js
+++ b/lib/patchResponse.js
@@ -1,8 +1,8 @@
 const attachDataset = require('./attachDataset')
 const attachQuadStream = require('./attachQuadStream')
 
-function patchResponse (res, factory, fetch, parsers) {
-  attachQuadStream(res, fetch, parsers)
+function patchResponse (res, factory, fetch, parsers, options) {
+  attachQuadStream(res, fetch, parsers, options)
 
   if (factory) {
     attachDataset(res, factory)

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -12,6 +12,18 @@ const rdfFetch = require('..')
 
 describe('response', () => {
   describe('quadStream', () => {
+    it('should handle missing Content-Type header', async () => {
+      const id = '/response/quadstream/function'
+
+      virtualResource({ id, contentType: undefined })
+
+      // The DOAP vocab doesn't actually return any Content-Type header at all...
+      const res = await rdfFetch('http://usefulinc.com/ns/doap#', { formats })
+      await res.quadStream()
+
+      strictEqual(typeof res.quadStream, 'function')
+    })
+
     it('should be a function', async () => {
       const id = '/response/quadstream/function'
 

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -12,13 +12,26 @@ const rdfFetch = require('..')
 
 describe('response', () => {
   describe('quadStream', () => {
-    it('should handle missing Content-Type header', async () => {
+    it('should throw if missing Content-Type header and no fallback', async () => {
       const id = '/response/quadstream/function'
 
+      // The DOAP vocab (for example) doesn't actually return any Content-Type header at all...
       virtualResource({ id, contentType: undefined })
 
-      // The DOAP vocab doesn't actually return any Content-Type header at all...
-      const res = await rdfFetch('http://usefulinc.com/ns/doap#', { formats })
+      await rejects(async () => {
+        const res = await rdfFetch('http://usefulinc.com/ns/doap#', { formats })
+        await res.quadStream()
+      })
+    })
+
+    it('should fallback to provided content-type if missing Content-Type header', async () => {
+      const id = '/response/quadstream/function'
+
+      // The DOAP vocab (for example) doesn't actually return any Content-Type header at all...
+      virtualResource({ id, contentType: undefined })
+
+      const res = await rdfFetch('http://usefulinc.com/ns/doap#',
+        { formats, headers: { 'content-type': 'application/rdf+xml' } })
       await res.quadStream()
 
       strictEqual(typeof res.quadStream, 'function')

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ describe('@rdfjs/fetch-lite', () => {
     strictEqual(typeof rdfFetch, 'function')
   })
 
-  it('should throw an error if now formats are given', () => {
+  it('should throw an error if no formats are given', () => {
     return rejects(async () => {
       await rdfFetch('')
     })


### PR DESCRIPTION
This PR is just a suggestion to address a specific problem encountered with the DOAP vocab served from: http://usefulinc.com/ns/doap#
This vocab is returned without a Content-Type header at all. It just so happens to return RDF/XML, which is why this PR defaults to that serialization format in the absence of a Content-Type value.
Perhaps a better update would be extending the `options` object to `rdfFetch()` include a `contentTypeOverride` value for cases where the developer wants to provide a specific serialization returned by a server who doesn't return a Content Type, but perhaps this DOAP server behaviour is unique enough to not warrant that (i.e., this very old DOAP vocab is the first one that I've encountered (in over 70 public vocabs) that fails to provide a Content-Type header value with it's response), so I think this workaround might be fine for now...?