### PR TITLE
provide helpful error if response is missing Content-Type

### DIFF
--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -2,6 +2,12 @@ const jsonldContextLinkUrl = require('./jsonldContextLinkUrl')
 
 function attachQuadStream (res, fetch, parsers) {
   res.quadStream = async () => {
+    if (!res.headers.get('content-type')) {
+      return Promise.reject(new Error('Fetch response is missing HTTP Content-Type header - without' +
+        ' this we can\'t determine which parser to use (consider setting this header yourself' +
+        ' on the response object before attempting to process it).'))
+    }
+
     // content type from headers without encoding, if given
     let contentType = res.headers.get('content-type').split(';')[0]
 


### PR DESCRIPTION
I don't think the README needs to explain this behavior, as a missing Content-Type header should be a rare edge-case, and providing a descriptive error message (with a suggested workaround) should probably be enough.