### PR TITLE
chore: shortened error message for missing content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The following methods are attached to the standard fetch response object:
 - async `dataset()`: This method uses the `quadStream()` method to parse the content and will pipe it into a dataset, which is also the return value.
   This method is only available when the `factory` option is given.
 
+The `Content-Type` header of the response can be changed or set before calling `quadStream()` or `dataset()`.
+That allows enforcing a specific parser or can be used to fix a lacking header.
+
 ### Example
 
 This example fetches data from a resource on Wikidata.

--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -3,9 +3,7 @@ const jsonldContextLinkUrl = require('./jsonldContextLinkUrl')
 function attachQuadStream (res, fetch, parsers) {
   res.quadStream = async () => {
     if (!res.headers.get('content-type')) {
-      return Promise.reject(new Error('Fetch response is missing HTTP Content-Type header - without' +
-        ' this we can\'t determine which parser to use (consider setting this header yourself' +
-        ' on the response object before attempting to process it).'))
+      throw new Error('Content-Type header missing: couldn\'t determine parser')
     }
 
     // content type from headers without encoding, if given

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -132,10 +132,9 @@ describe('response', () => {
       await rejects(async () => {
         const res = await rdfFetch(`http://example.org${id}`, { formats })
         await res.quadStream()
-      }, (err) => {
-        strictEqual(err.message, 'Fetch response is missing HTTP Content-Type header - without' +
-          ' this we can\'t determine which parser to use (consider setting this header yourself' +
-          ' on the response object before attempting to process it).')
+      }, err => {
+        strictEqual(err.message.includes('Content-Type'), true)
+
         return true
       })
     })


### PR DESCRIPTION
Shortened the error message for the missing content-type header and give more details in the readme.